### PR TITLE
Minor: Ran cargo machete - removed js-sys, console_log, serde.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.6.5", features = ["csr"] }
-serde = { version = "1", features = ["derive"] }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3.64", features = [
   'Document',
@@ -28,8 +27,6 @@ web-sys = { version = "0.3.64", features = [
   'console',
   'ContextAttributes2d',
 ] }
-js-sys = "0.3.64"
 
-console_log = { version = "1", features = ["color"] }
 wasm-bindgen-futures = "0.4.41"
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
I love this example...

This skeleton app has some really useful code snippets...

by way of giving back .. When I reviewed it I ran [cargo- machete](https://crates.io/crates/cargo-machete) which told me the  dependency list if a little inflated.